### PR TITLE
Implement executor-based printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ OkHttpClient.Builder client = new OkHttpClient.Builder();
 //                      Log.w(tag, msg);
 //                  }
 //              })
+//              .executor(Executors.newSingleThreadExecutor())
                .build());
         OkHttpClient okHttpClient = client.build();
 
@@ -151,6 +152,11 @@ Maven:
 	    <version>2.0.4</version>
 </dependency>
 ```
+
+
+Executor
+--------
+Add executor for allows to perform sequential concurrent print.
 
 Level
 --------

--- a/app/src/androidTest/java/ihsanbal/com/logginginterceptor/ui/InterceptorsTest.java
+++ b/app/src/androidTest/java/ihsanbal/com/logginginterceptor/ui/InterceptorsTest.java
@@ -33,6 +33,14 @@ public class InterceptorsTest {
     }
 
     @Test
+    public void interceptorsZipTest() {
+        ViewInteraction buttonPost = onView(
+                allOf(withId(R.id.button_zip), withText("ZIP"), isDisplayed()));
+        buttonPost.perform(click());
+        buttonPost.check(matches(isDisplayed()));
+    }
+
+    @Test
     public void interceptorsGetTest() {
         ViewInteraction buttonPost = onView(
                 allOf(withId(R.id.button_get), withText("GET"), isDisplayed()));

--- a/app/src/main/java/ihsanbal/com/logginginterceptor/di/NetModule.java
+++ b/app/src/main/java/ihsanbal/com/logginginterceptor/di/NetModule.java
@@ -3,6 +3,8 @@ package ihsanbal.com.logginginterceptor.di;
 import com.ihsanbal.logging.Level;
 import com.ihsanbal.logging.LoggingInterceptor;
 
+import java.util.concurrent.Executors;
+
 import javax.inject.Singleton;
 
 import dagger.Module;
@@ -35,12 +37,10 @@ public class NetModule {
                 .loggable(BuildConfig.DEBUG)
                 .setLevel(Level.BASIC)
                 .log(Platform.INFO)
-                .tag("LoggingI")
-                .request("Request")
-                .response("Response")
                 .addHeader("version", BuildConfig.VERSION_NAME)
                 .addQueryParam("query", "0")
-//                .logger((level, tag, msg) -> Log.w(tag, msg))
+//              .logger((level, tag, msg) -> Log.w(tag, msg))
+//              .executor(Executors.newSingleThreadExecutor())
                 .build());
         return client.build();
     }

--- a/app/src/main/java/ihsanbal/com/logginginterceptor/ui/MainActivity.java
+++ b/app/src/main/java/ihsanbal/com/logginginterceptor/ui/MainActivity.java
@@ -33,6 +33,7 @@ import okhttp3.MediaType;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
+import rx.Observable;
 import rx.Observer;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.schedulers.Schedulers;
@@ -61,6 +62,17 @@ public class MainActivity extends BaseCompatActivity {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribeOn(Schedulers.io())
                 .subscribe(getSubscriber());
+    }
+
+    @OnClick(R.id.button_zip)
+    void callZip() {
+        Observable<ResponseBody> observablePost = api.post(new Body())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeOn(Schedulers.io());
+        Observable<ResponseBody> observableGet = api.get()
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeOn(Schedulers.io());
+        Observable.zip(observablePost, observableGet, (o, o1) -> o).subscribe(getSubscriber());
     }
 
     @OnClick(R.id.button_get)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,6 +14,12 @@
         android:text="@string/req_post" />
 
     <android.support.v7.widget.AppCompatButton
+        android:id="@+id/button.zip"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/req_zip" />
+
+    <android.support.v7.widget.AppCompatButton
         android:id="@+id/button.get"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,5 @@
     <string name="req_put">PUT</string>
     <string name="req_pdf">FILE</string>
     <string name="req_pdf_upload">UPLOAD</string>
+    <string name="req_zip">ZIP</string>
 </resources>

--- a/lib/src/main/java/com/ihsanbal/logging/LoggingInterceptor.java
+++ b/lib/src/main/java/com/ihsanbal/logging/LoggingInterceptor.java
@@ -32,44 +32,6 @@ public class LoggingInterceptor implements Interceptor {
         this.isDebug = builder.isDebug;
     }
 
-    private static Runnable createPrintJsonRequestRunnable(final LoggingInterceptor.Builder builder, final Request request) {
-        return new Runnable() {
-            @Override
-            public void run() {
-                Printer.printJsonRequest(builder, request);
-            }
-        };
-    }
-
-    private static Runnable createFileRequestRunnable(final LoggingInterceptor.Builder builder, final Request request) {
-        return new Runnable() {
-            @Override
-            public void run() {
-                Printer.printFileRequest(builder, request);
-            }
-        };
-    }
-
-    private static Runnable createPrintJsonResponseRunnable(final LoggingInterceptor.Builder builder, final long chainMs, final boolean isSuccessful,
-                                                            final int code, final String headers, final String bodyString, final List<String> segments, final String message, final String responseUrl) {
-        return new Runnable() {
-            @Override
-            public void run() {
-                Printer.printJsonResponse(builder, chainMs, isSuccessful, code, headers, bodyString, segments, message, responseUrl);
-            }
-        };
-    }
-
-    private static Runnable createFileResponseRunnable(final LoggingInterceptor.Builder builder, final long chainMs, final boolean isSuccessful,
-                                                       final int code, final String headers, final List<String> segments, final String message) {
-        return new Runnable() {
-            @Override
-            public void run() {
-                Printer.printFileResponse(builder, chainMs, isSuccessful, code, headers, segments, message);
-            }
-        };
-    }
-
     @Override
     public Response intercept(Chain chain) throws IOException {
         Request request = chain.request();
@@ -177,6 +139,44 @@ public class LoggingInterceptor implements Interceptor {
                 || subtype.contains("xml")
                 || subtype.contains("plain")
                 || subtype.contains("html"));
+    }
+
+    private static Runnable createPrintJsonRequestRunnable(final LoggingInterceptor.Builder builder, final Request request) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                Printer.printJsonRequest(builder, request);
+            }
+        };
+    }
+
+    private static Runnable createFileRequestRunnable(final LoggingInterceptor.Builder builder, final Request request) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                Printer.printFileRequest(builder, request);
+            }
+        };
+    }
+
+    private static Runnable createPrintJsonResponseRunnable(final LoggingInterceptor.Builder builder, final long chainMs, final boolean isSuccessful,
+                                                            final int code, final String headers, final String bodyString, final List<String> segments, final String message, final String responseUrl) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                Printer.printJsonResponse(builder, chainMs, isSuccessful, code, headers, bodyString, segments, message, responseUrl);
+            }
+        };
+    }
+
+    private static Runnable createFileResponseRunnable(final LoggingInterceptor.Builder builder, final long chainMs, final boolean isSuccessful,
+                                                       final int code, final String headers, final List<String> segments, final String message) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                Printer.printFileResponse(builder, chainMs, isSuccessful, code, headers, segments, message);
+            }
+        };
     }
 
     @SuppressWarnings({"unused", "SameParameterValue"})

--- a/lib/src/main/java/com/ihsanbal/logging/LoggingInterceptor.java
+++ b/lib/src/main/java/com/ihsanbal/logging/LoggingInterceptor.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 import okhttp3.Headers;
@@ -23,12 +24,50 @@ import okhttp3.internal.platform.Platform;
 
 public class LoggingInterceptor implements Interceptor {
 
-    private boolean isDebug;
-    private Builder builder;
+    private final boolean isDebug;
+    private final Builder builder;
 
     private LoggingInterceptor(Builder builder) {
         this.builder = builder;
         this.isDebug = builder.isDebug;
+    }
+
+    private static Runnable createPrintJsonRequestRunnable(final LoggingInterceptor.Builder builder, final Request request) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                Printer.printJsonRequest(builder, request);
+            }
+        };
+    }
+
+    private static Runnable createFileRequestRunnable(final LoggingInterceptor.Builder builder, final Request request) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                Printer.printFileRequest(builder, request);
+            }
+        };
+    }
+
+    private static Runnable createPrintJsonResponseRunnable(final LoggingInterceptor.Builder builder, final long chainMs, final boolean isSuccessful,
+                                                            final int code, final String headers, final String bodyString, final List<String> segments, final String message, final String responseUrl) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                Printer.printJsonResponse(builder, chainMs, isSuccessful, code, headers, bodyString, segments, message, responseUrl);
+            }
+        };
+    }
+
+    private static Runnable createFileResponseRunnable(final LoggingInterceptor.Builder builder, final long chainMs, final boolean isSuccessful,
+                                                       final int code, final String headers, final List<String> segments, final String message) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                Printer.printFileResponse(builder, chainMs, isSuccessful, code, headers, segments, message);
+            }
+        };
     }
 
     @Override
@@ -72,10 +111,20 @@ public class LoggingInterceptor implements Interceptor {
             rSubtype = requestBody.contentType().subtype();
         }
 
+        Executor executor = builder.executor;
+
         if (isNotFileRequest(rSubtype)) {
-            Printer.printJsonRequest(builder, request);
+            if (executor != null) {
+                executor.execute(createPrintJsonRequestRunnable(builder, request));
+            } else {
+                Printer.printJsonRequest(builder, request);
+            }
         } else {
-            Printer.printFileRequest(builder, request);
+            if (executor != null) {
+                executor.execute(createFileRequestRunnable(builder, request));
+            } else {
+                Printer.printFileRequest(builder, request);
+            }
         }
 
         final long st = System.nanoTime();
@@ -100,11 +149,21 @@ public class LoggingInterceptor implements Interceptor {
         if (isNotFileRequest(subtype)) {
             final String bodyString = Printer.getJsonString(responseBody.string());
             final String url = response.request().url().toString();
-            Printer.printJsonResponse(builder, chainMs, isSuccessful, code, header, bodyString,
-                    segmentList, message, url);
+
+            if (executor != null) {
+                executor.execute(createPrintJsonResponseRunnable(builder, chainMs, isSuccessful, code, header, bodyString,
+                        segmentList, message, url));
+            } else {
+                Printer.printJsonResponse(builder, chainMs, isSuccessful, code, header, bodyString,
+                        segmentList, message, url);
+            }
             body = ResponseBody.create(contentType, bodyString);
         } else {
-            Printer.printFileResponse(builder, chainMs, isSuccessful, code, header, segmentList, message);
+            if (executor != null) {
+                executor.execute(createFileResponseRunnable(builder, chainMs, isSuccessful, code, header, segmentList, message));
+            } else {
+                Printer.printFileResponse(builder, chainMs, isSuccessful, code, header, segmentList, message);
+            }
             return response;
         }
 
@@ -124,14 +183,15 @@ public class LoggingInterceptor implements Interceptor {
     public static class Builder {
 
         private static String TAG = "LoggingI";
+        private final HashMap<String, String> headers;
+        private final HashMap<String, String> queries;
         private boolean isDebug;
         private int type = Platform.INFO;
         private String requestTag;
         private String responseTag;
         private Level level = Level.BASIC;
         private Logger logger;
-        private final HashMap<String, String> headers;
-        private final HashMap<String, String> queries;
+        private Executor executor;
 
         public Builder() {
             headers = new HashMap<>();
@@ -144,6 +204,16 @@ public class LoggingInterceptor implements Interceptor {
 
         Level getLevel() {
             return level;
+        }
+
+        /**
+         * @param level set log level
+         * @return Builder
+         * @see Level
+         */
+        public Builder setLevel(Level level) {
+            this.level = level;
+            return this;
         }
 
         HashMap<String, String> getHeaders() {
@@ -166,6 +236,10 @@ public class LoggingInterceptor implements Interceptor {
             return logger;
         }
 
+        Executor getExecutor() {
+            return executor;
+        }
+
         /**
          * @param name  Filed
          * @param value Value
@@ -185,16 +259,6 @@ public class LoggingInterceptor implements Interceptor {
          */
         public Builder addQueryParam(String name, String value) {
             queries.put(name, value);
-            return this;
-        }
-
-        /**
-         * @param level set log level
-         * @return Builder
-         * @see Level
-         */
-        public Builder setLevel(Level level) {
-            this.level = level;
             return this;
         }
 
@@ -257,6 +321,16 @@ public class LoggingInterceptor implements Interceptor {
          */
         public Builder logger(Logger logger) {
             this.logger = logger;
+            return this;
+        }
+
+        /**
+         * @param executor manual executor for printing
+         * @return Builder
+         * @see Logger
+         */
+        public Builder executor(Executor executor) {
+            this.executor = executor;
             return this;
         }
 


### PR DESCRIPTION
Add a capability to provide Executor for _LoggingInterceptor.Builder_ to execute printing on. Combined with single worker threaded Executor (_Executors.newSingleThreadExecutor()_) allows to perform sequential concurrent print.