### PR TITLE
Fix #46 issue when pretty formatted logs prints badly.

### DIFF
--- a/app/src/main/java/ihsanbal/com/logginginterceptor/di/NetModule.java
+++ b/app/src/main/java/ihsanbal/com/logginginterceptor/di/NetModule.java
@@ -2,11 +2,15 @@ package ihsanbal.com.logginginterceptor.di;
 
 import com.ihsanbal.logging.Level;
 import com.ihsanbal.logging.LoggingInterceptor;
+
+import java.util.concurrent.Executors;
+
+import javax.inject.Singleton;
+
 import dagger.Module;
 import dagger.Provides;
 import ihsanbal.com.logginginterceptor.BuildConfig;
 import ihsanbal.com.logginginterceptor.api.Api;
-import javax.inject.Singleton;
 import okhttp3.OkHttpClient;
 import okhttp3.internal.platform.Platform;
 import retrofit2.Retrofit;
@@ -19,11 +23,11 @@ import retrofit2.converter.gson.GsonConverterFactory;
 @Module
 public class NetModule {
 
-  private String mEndPoint;
+    private String mEndPoint;
 
-  public NetModule(String endpoint) {
-    mEndPoint = endpoint;
-  }
+    public NetModule(String endpoint) {
+        mEndPoint = endpoint;
+    }
 
     @Provides
     @Singleton
@@ -35,27 +39,27 @@ public class NetModule {
                 .log(Platform.INFO)
                 .addHeader("version", BuildConfig.VERSION_NAME)
                 .addQueryParam("query", "0")
-                .useAndroidStudio_v3_LogsHack(true)
-//              .logger((level, tag, msg) -> Log.w(tag, msg))
-//              .executor(Executors.newSingleThreadExecutor())
+                .enableAndroidStudio_v3_LogsHack(true)
+//                .logger((level, tag, msg) -> Log.w(tag, msg))
+                .executor(Executors.newSingleThreadExecutor())
                 .build());
         return client.build();
     }
 
-  @Provides
-  @Singleton
-  Retrofit provideRetrofit(OkHttpClient okHttpClient) {
-    return new Retrofit.Builder()
-        .addConverterFactory(GsonConverterFactory.create())
-        .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
-        .baseUrl(mEndPoint)
-        .client(okHttpClient)
-        .build();
-  }
+    @Provides
+    @Singleton
+    Retrofit provideRetrofit(OkHttpClient okHttpClient) {
+        return new Retrofit.Builder()
+                .addConverterFactory(GsonConverterFactory.create())
+                .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+                .baseUrl(mEndPoint)
+                .client(okHttpClient)
+                .build();
+    }
 
-  @Provides
-  @Singleton
-  Api provideApi(Retrofit retrofit) {
-    return retrofit.create(Api.class);
-  }
+    @Provides
+    @Singleton
+    Api provideApi(Retrofit retrofit) {
+        return retrofit.create(Api.class);
+    }
 }

--- a/app/src/main/java/ihsanbal/com/logginginterceptor/di/NetModule.java
+++ b/app/src/main/java/ihsanbal/com/logginginterceptor/di/NetModule.java
@@ -2,15 +2,11 @@ package ihsanbal.com.logginginterceptor.di;
 
 import com.ihsanbal.logging.Level;
 import com.ihsanbal.logging.LoggingInterceptor;
-
-import java.util.concurrent.Executors;
-
-import javax.inject.Singleton;
-
 import dagger.Module;
 import dagger.Provides;
 import ihsanbal.com.logginginterceptor.BuildConfig;
 import ihsanbal.com.logginginterceptor.api.Api;
+import javax.inject.Singleton;
 import okhttp3.OkHttpClient;
 import okhttp3.internal.platform.Platform;
 import retrofit2.Retrofit;
@@ -23,11 +19,11 @@ import retrofit2.converter.gson.GsonConverterFactory;
 @Module
 public class NetModule {
 
-    private String mEndPoint;
+  private String mEndPoint;
 
-    public NetModule(String endpoint) {
-        mEndPoint = endpoint;
-    }
+  public NetModule(String endpoint) {
+    mEndPoint = endpoint;
+  }
 
     @Provides
     @Singleton
@@ -39,27 +35,27 @@ public class NetModule {
                 .log(Platform.INFO)
                 .addHeader("version", BuildConfig.VERSION_NAME)
                 .addQueryParam("query", "0")
+                .useAndroidStudio_v3_LogsHack(true)
 //              .logger((level, tag, msg) -> Log.w(tag, msg))
 //              .executor(Executors.newSingleThreadExecutor())
                 .build());
         return client.build();
     }
 
-    @Provides
-    @Singleton
-    Retrofit provideRetrofit(OkHttpClient okHttpClient) {
-        return new Retrofit.Builder()
-                .addConverterFactory(GsonConverterFactory.create())
-                .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
-                .baseUrl(mEndPoint)
-                .client(okHttpClient)
-                .build();
-    }
+  @Provides
+  @Singleton
+  Retrofit provideRetrofit(OkHttpClient okHttpClient) {
+    return new Retrofit.Builder()
+        .addConverterFactory(GsonConverterFactory.create())
+        .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+        .baseUrl(mEndPoint)
+        .client(okHttpClient)
+        .build();
+  }
 
-    @Provides
-    @Singleton
-    Api provideApi(Retrofit retrofit) {
-        return retrofit.create(Api.class);
-    }
-
+  @Provides
+  @Singleton
+  Api provideApi(Retrofit retrofit) {
+    return retrofit.create(Api.class);
+  }
 }

--- a/lib/src/main/java/com/ihsanbal/logging/I.java
+++ b/lib/src/main/java/com/ihsanbal/logging/I.java
@@ -9,15 +9,16 @@ import okhttp3.internal.platform.Platform;
  * @author ihsan on 10/02/2017.
  */
 class I {
-    private static String[] prefix = { ". ", " ." };
+    private static String[] prefix = {". ", " ."};
     private static int index = 0;
 
     protected I() {
         throw new UnsupportedOperationException();
     }
 
-    static void log(int type, String tag, String msg) {
-        java.util.logging.Logger logger = java.util.logging.Logger.getLogger(tag);
+    static void log(int type, String tag, String msg, final boolean isLogHackEnable) {
+        final String finalTag = getFinalTag(tag, isLogHackEnable);
+        java.util.logging.Logger logger = java.util.logging.Logger.getLogger(isLogHackEnable ? finalTag : tag);
         switch (type) {
             case Platform.INFO:
                 logger.log(Level.INFO, msg);
@@ -28,22 +29,8 @@ class I {
         }
     }
 
-    static void log(int type, String tag, String msg, final boolean useLogsHack) {
-        final String finalTag = getFinalTag(tag, useLogsHack);
-
-        java.util.logging.Logger logger = java.util.logging.Logger.getLogger(finalTag);
-        switch (type) {
-          case Platform.INFO:
-            logger.log(Level.INFO, msg);
-            break;
-          default:
-            logger.log(Level.WARNING, msg);
-            break;
-        }
-    }
-
-    static String getFinalTag(final String tag, final boolean useLogsHack) {
-        if (useLogsHack) {
+    private static String getFinalTag(final String tag, final boolean isLogHackEnable) {
+        if (isLogHackEnable) {
             index = index ^ 1;
             return prefix[index] + tag;
         } else {

--- a/lib/src/main/java/com/ihsanbal/logging/I.java
+++ b/lib/src/main/java/com/ihsanbal/logging/I.java
@@ -9,6 +9,8 @@ import okhttp3.internal.platform.Platform;
  * @author ihsan on 10/02/2017.
  */
 class I {
+    private static String[] prefix = { ". ", " ." };
+    private static int index = 0;
 
     protected I() {
         throw new UnsupportedOperationException();
@@ -23,6 +25,29 @@ class I {
             default:
                 logger.log(Level.WARNING, msg);
                 break;
+        }
+    }
+
+    static void log(int type, String tag, String msg, final boolean useLogsHack) {
+        final String finalTag = getFinalTag(tag, useLogsHack);
+
+        java.util.logging.Logger logger = java.util.logging.Logger.getLogger(finalTag);
+        switch (type) {
+          case Platform.INFO:
+            logger.log(Level.INFO, msg);
+            break;
+          default:
+            logger.log(Level.WARNING, msg);
+            break;
+        }
+    }
+
+    static String getFinalTag(final String tag, final boolean useLogsHack) {
+        if (useLogsHack) {
+            index = index ^ 1;
+            return prefix[index] + tag;
+        } else {
+            return tag;
         }
     }
 }

--- a/lib/src/main/java/com/ihsanbal/logging/LoggingInterceptor.java
+++ b/lib/src/main/java/com/ihsanbal/logging/LoggingInterceptor.java
@@ -175,7 +175,7 @@ public class LoggingInterceptor implements Interceptor {
         private static String TAG = "LoggingI";
         private final HashMap<String, String> headers;
         private final HashMap<String, String> queries;
-        private boolean useLogHack = false;
+        private boolean isLogHackEnable = false;
         private boolean isDebug;
         private int type = Platform.INFO;
         private String requestTag;
@@ -231,8 +231,8 @@ public class LoggingInterceptor implements Interceptor {
             return executor;
         }
 
-        boolean shouldUseLogHack() {
-          return useLogHack;
+        boolean isLogHackEnable() {
+          return isLogHackEnable;
         }
 
       /**
@@ -338,8 +338,8 @@ public class LoggingInterceptor implements Interceptor {
          * @return Builder
          * @see Logger
          * */
-        public Builder useAndroidStudio_v3_LogsHack(final boolean useHack) {
-          useLogHack = useHack;
+        public Builder enableAndroidStudio_v3_LogsHack(final boolean useHack) {
+          isLogHackEnable = useHack;
           return this;
         }
 

--- a/lib/src/main/java/com/ihsanbal/logging/LoggingInterceptor.java
+++ b/lib/src/main/java/com/ihsanbal/logging/LoggingInterceptor.java
@@ -175,6 +175,7 @@ public class LoggingInterceptor implements Interceptor {
         private static String TAG = "LoggingI";
         private final HashMap<String, String> headers;
         private final HashMap<String, String> queries;
+        private boolean useLogHack = false;
         private boolean isDebug;
         private int type = Platform.INFO;
         private String requestTag;
@@ -230,7 +231,11 @@ public class LoggingInterceptor implements Interceptor {
             return executor;
         }
 
-        /**
+        boolean shouldUseLogHack() {
+          return useLogHack;
+        }
+
+      /**
          * @param name  Filed
          * @param value Value
          * @return Builder
@@ -322,6 +327,20 @@ public class LoggingInterceptor implements Interceptor {
         public Builder executor(Executor executor) {
             this.executor = executor;
             return this;
+        }
+
+        /**
+         * Call this if you want to have formatted pretty output in Android Studio logCat.
+         * By default this 'hack' is not applied.
+         *
+         * @param useHack setup builder to use hack for Android Studio v3+ in order to have nice
+         * output as it was in previous A.S. versions.
+         * @return Builder
+         * @see Logger
+         * */
+        public Builder useAndroidStudio_v3_LogsHack(final boolean useHack) {
+          useLogHack = useHack;
+          return this;
         }
 
         public LoggingInterceptor build() {

--- a/lib/src/main/java/com/ihsanbal/logging/Printer.java
+++ b/lib/src/main/java/com/ihsanbal/logging/Printer.java
@@ -52,14 +52,14 @@ class Printer {
         String requestBody = LINE_SEPARATOR + BODY_TAG + LINE_SEPARATOR + bodyToString(request);
         String tag = builder.getTag(true);
         if (builder.getLogger() == null)
-            I.log(builder.getType(), tag, REQUEST_UP_LINE, builder.shouldUseLogHack());
-        logLines(builder.getType(), tag, new String[]{URL_TAG + request.url()}, builder.getLogger(), false, builder.shouldUseLogHack());
-        logLines(builder.getType(), tag, getRequest(request, builder.getLevel()), builder.getLogger(), true, builder.shouldUseLogHack());
+            I.log(builder.getType(), tag, REQUEST_UP_LINE, builder.isLogHackEnable());
+        logLines(builder.getType(), tag, new String[]{URL_TAG + request.url()}, builder.getLogger(), false, builder.isLogHackEnable());
+        logLines(builder.getType(), tag, getRequest(request, builder.getLevel()), builder.getLogger(), true, builder.isLogHackEnable());
         if (builder.getLevel() == Level.BASIC || builder.getLevel() == Level.BODY) {
-            logLines(builder.getType(), tag, requestBody.split(LINE_SEPARATOR), builder.getLogger(),true, builder.shouldUseLogHack());
+            logLines(builder.getType(), tag, requestBody.split(LINE_SEPARATOR), builder.getLogger(),true, builder.isLogHackEnable());
         }
         if (builder.getLogger() == null)
-            I.log(builder.getType(), tag, END_LINE, builder.shouldUseLogHack());
+            I.log(builder.getType(), tag, END_LINE, builder.isLogHackEnable());
     }
 
     static void printJsonResponse(LoggingInterceptor.Builder builder, long chainMs, boolean isSuccessful,
@@ -71,46 +71,46 @@ class Printer {
             builder.getLevel(), segments, message);
 
         if (builder.getLogger() == null) {
-            I.log(builder.getType(), tag, RESPONSE_UP_LINE, builder.shouldUseLogHack());
+            I.log(builder.getType(), tag, RESPONSE_UP_LINE, builder.isLogHackEnable());
         }
 
-        logLines(builder.getType(), tag, urlLine, builder.getLogger(), true, builder.shouldUseLogHack());
-        logLines(builder.getType(), tag, response, builder.getLogger(), true, builder.shouldUseLogHack());
+        logLines(builder.getType(), tag, urlLine, builder.getLogger(), true, builder.isLogHackEnable());
+        logLines(builder.getType(), tag, response, builder.getLogger(), true, builder.isLogHackEnable());
 
         if (builder.getLevel() == Level.BASIC || builder.getLevel() == Level.BODY) {
             logLines(builder.getType(), tag, responseBody.split(LINE_SEPARATOR), builder.getLogger(),
-                true, builder.shouldUseLogHack());
+                true, builder.isLogHackEnable());
         }
         if (builder.getLogger() == null) {
-            I.log(builder.getType(), tag, END_LINE, builder.shouldUseLogHack());
+            I.log(builder.getType(), tag, END_LINE, builder.isLogHackEnable());
         }
     }
 
     static void printFileRequest(LoggingInterceptor.Builder builder, Request request) {
         String tag = builder.getTag(true);
         if (builder.getLogger() == null)
-            I.log(builder.getType(), tag, REQUEST_UP_LINE, builder.shouldUseLogHack());
+            I.log(builder.getType(), tag, REQUEST_UP_LINE, builder.isLogHackEnable());
         logLines(builder.getType(), tag, new String[]{URL_TAG + request.url()}, builder.getLogger(),
-            false, builder.shouldUseLogHack());
+            false, builder.isLogHackEnable());
         logLines(builder.getType(), tag, getRequest(request, builder.getLevel()), builder.getLogger(),
-            true, builder.shouldUseLogHack());
+            true, builder.isLogHackEnable());
         if (builder.getLevel() == Level.BASIC || builder.getLevel() == Level.BODY) {
-            logLines(builder.getType(), tag, OMITTED_REQUEST, builder.getLogger(), true, builder.shouldUseLogHack());
+            logLines(builder.getType(), tag, OMITTED_REQUEST, builder.getLogger(), true, builder.isLogHackEnable());
         }
         if (builder.getLogger() == null)
-            I.log(builder.getType(), tag, END_LINE, builder.shouldUseLogHack());
+            I.log(builder.getType(), tag, END_LINE, builder.isLogHackEnable());
     }
 
     static void printFileResponse(LoggingInterceptor.Builder builder, long chainMs, boolean isSuccessful,
                                   int code, String headers, List<String> segments, String message) {
         String tag = builder.getTag(false);
         if (builder.getLogger() == null)
-            I.log(builder.getType(), tag, RESPONSE_UP_LINE, builder.shouldUseLogHack());
+            I.log(builder.getType(), tag, RESPONSE_UP_LINE, builder.isLogHackEnable());
         logLines(builder.getType(), tag, getResponse(headers, chainMs, code, isSuccessful,
-                builder.getLevel(), segments, message), builder.getLogger(), true, builder.shouldUseLogHack());
-        logLines(builder.getType(), tag, OMITTED_RESPONSE, builder.getLogger(), true, builder.shouldUseLogHack());
+                builder.getLevel(), segments, message), builder.getLogger(), true, builder.isLogHackEnable());
+        logLines(builder.getType(), tag, OMITTED_RESPONSE, builder.getLogger(), true, builder.isLogHackEnable());
         if (builder.getLogger() == null)
-            I.log(builder.getType(), tag, END_LINE, builder.shouldUseLogHack());
+            I.log(builder.getType(), tag, END_LINE, builder.isLogHackEnable());
     }
 
     private static String[] getRequest(Request request, Level level) {
@@ -177,8 +177,7 @@ class Printer {
                 if (logger == null) {
                     I.log(type, tag, DEFAULT_LINE + line.substring(start, end), useLogHack);
                 } else {
-                    final String finalTag = I.getFinalTag(tag, useLogHack);
-                    logger.log(type, finalTag, line.substring(start, end));
+                    logger.log(type, tag, line.substring(start, end));
                 }
             }
         }


### PR DESCRIPTION
Fix #46 issue when pretty formatted logs prints badly. It happens because of Android Studio changes since 3.0 release.

Fix with some sort of hack. Modified original tag value by playing with 'dots'.
Idea of hack is from @liangchenhe55. He proposed it here https://github.com/orhanobut/logger/issues/203.
Also I don't sure about API of my fix, and don't like static fields in I class. But behaviour logs printing already fixed in AS v3.2 canary, as I know. So as temporary workaround I think it will be good enough.